### PR TITLE
技術発信を主役にしたプロフィールREADMEへ刷新

### DIFF
--- a/.github/workflows/update-articles.yml
+++ b/.github/workflows/update-articles.yml
@@ -1,0 +1,28 @@
+name: Update latest articles
+
+# README の「🆕 最新記事」セクションを Qiita の RSS から自動更新する。
+# <!-- BLOG-POST-LIST:START --> 〜 <!-- BLOG-POST-LIST:END --> の間を差し替える。
+
+on:
+  schedule:
+    # 毎日 00:00 UTC（日本時間 09:00）に更新
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Pull latest Qiita articles into README
+        uses: gautamkrishnar/blog-post-workflow@v1
+        with:
+          feed_list: "https://qiita.com/nomurasan/feed"
+          max_post_count: 5
+          commit_message: "chore: update latest articles"
+          template: "- 📝 [$title]($url)$newline"

--- a/README.md
+++ b/README.md
@@ -1,57 +1,116 @@
-<!--
+<!-- ===================== HERO ===================== -->
+<div align="center">
 
-### プロフィール
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:1a2a6c,50:2a5298,100:b21f1f&height=200&section=header&text=shimajima-eiji&fontSize=46&fontColor=ffffff&fontAlignY=38&desc=Forward%20Deployed%20Engineer%20%2F%20Tech%20Writer&descSize=20&descAlignY=60" alt="header" />
 
-[ポートフォリオサイト](https://shimajima-eiji.github.io) でスライド形式の自己紹介を公開しています。
-
----
-
-> [!NOTE]
-> ようこそ！<br>
-> このページは
-
-> [!TIP]
-> ## 自己紹介
-> - LinuC Open NetWork
-> 
-> ## [2024] 活動記録・分析
-> ### コミュニティ
-
-> [!IMPORTANT]
-> # コンタクト<br>
-> 様々なエージェントサイトに登録しておりますので、そちらをご活用ください。<br>
-> GitHubプロフィールを閲覧いただいた、と一言添えていただければ喜びます！
-
----
-
-### 技術情報
-
-| ページリンク | 概要 |
-| ----------- | ---- |
-| [ポートフォリオサイト](https://shimajima-eiji.github.io/) | スライド形式の自己紹介・活動記録 |
-| [LAPRAS](https://lapras.com/person) | 市場価値スコア 4.21（上位 0.75%）/ 技術力 4.30（上位 0.46%）|
-| [Prairie Cards](https://my.prairie.cards/u/nomuraya) | Forward Deployed Engineer — 名刺代わり |
-| [外部ポートフォリオ](https://www.wantedly.com/id/nomuraya) | Wantedlyプロフィール（アカウント不要で閲覧可） |
-| [公開リポジトリ一覧](https://github.com/shimajima-eiji?tab=repositories) | 公開可能なプロジェクト・実験的コード |
-
-<a href="https://github-readme-stats.vercel.app/api?username=shimajima-eiji&count_private=true&show_icons=true">
-  <img alt="GitHubでの活動記録" src="https://github-readme-stats.vercel.app/api?username=shimajima-eiji&count_private=true&show_icons=true" />
+<a href="https://qiita.com/nomurasan">
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=22&pause=1000&color=2A5298&center=true&vCenter=true&width=620&lines=Forward+Deployed+Engineer;I+write+about+AI+x+real-world+ops;Making+the+%22why%22+of+code+explainable" alt="typing" />
 </a>
 
----
+<br/>
 
--->
+<a href="https://qiita.com/nomurasan"><img src="https://img.shields.io/badge/Qiita_%E3%82%92%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC-55C500?style=for-the-badge&logo=qiita&logoColor=white" alt="Follow on Qiita" /></a>
+<a href="https://shimajima-eiji.github.io/"><img src="https://img.shields.io/badge/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA-2a5298?style=for-the-badge&logo=githubpages&logoColor=white" alt="Portfolio" /></a>
 
+<br/>
+
+<img src="https://komarev.com/ghpvc/?username=shimajima-eiji&style=flat-square&color=2a5298&label=Profile+Views" alt="profile views" />
+
+</div>
+
+<!-- ===================== ABOUT ===================== -->
+
+## 👋 About
+
+**Forward Deployed Engineer** として顧客の現場に入り、AI を実務に組み込んで課題を解いています。
+その過程で得た **「現場で本当に効いた知見」を技術記事として継続発信** しているのが、私の主な活動です。
+丸暗記ではなく **“なぜそうなるのか” を言語化する** ことを大切にしています。
+
+<!-- ===================== WRITING (MAIN) ===================== -->
+
+## 📝 技術発信 / Writing
+
+書いている主なテーマ:
+
+- 🤖 **AI × 実務** — Claude Code を業務ワークフローに定着させる運用知見
+- ✅ **AI 生成物の品質管理** — 記事のファクトチェックを pre-commit ゲートで自動化する取り組み
+- 🌱 **初学者の「なぜ」を言語化** — `for` 文など、仕様から理解する解説（PHP / JavaScript）
+- 🚀 **発信のはじめ方** — Qiita 入門など、これから書く人へのガイド
+
+### 🆕 最新記事
+
+<!-- BLOG-POST-LIST:START -->
+<!-- 最新記事は GitHub Actions（Qiita RSS）が自動で差し込みます。初回実行までは空欄です。 -->
+- 📚 [Qiita で記事一覧を見る → @nomurasan](https://qiita.com/nomurasan)
+<!-- BLOG-POST-LIST:END -->
+
+▶ **もっと読む / フォロー:** [Qiita @nomurasan](https://qiita.com/nomurasan)
+
+<!-- ===================== TECH STACK ===================== -->
+
+## 🧰 Tech Stack
+
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
+![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat-square&logo=php&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=nodedotjs&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat-square&logo=githubactions&logoColor=white)
+![Claude](https://img.shields.io/badge/Claude_Code-D97757?style=flat-square&logo=anthropic&logoColor=white)
+![OpenAI](https://img.shields.io/badge/OpenAI_API-412991?style=flat-square&logo=openai&logoColor=white)
+
+<!-- ===================== LINKS ===================== -->
+
+## 🔗 Links
+
+| ページ | 概要 |
+| ----- | ---- |
+| 📚 [Qiita](https://qiita.com/nomurasan) | 技術記事（メインの発信先） |
+| 🖼️ [ポートフォリオサイト](https://shimajima-eiji.github.io/) | スライド形式の自己紹介・活動記録 |
+| 🪪 [Prairie Cards](https://my.prairie.cards/u/nomuraya) | Forward Deployed Engineer — 名刺代わり |
+| 🤝 [Wantedly](https://www.wantedly.com/id/nomuraya) | プロフィール（アカウント不要で閲覧可） |
+| 📦 [Repositories](https://github.com/shimajima-eiji?tab=repositories) | 公開プロジェクト・実験的コード |
+
+<!-- ===================== STATS ===================== -->
+
+## 📈 GitHub Activity
+
+<div align="center">
+
+<a href="https://github.com/shimajima-eiji">
+  <img height="165" alt="stats" src="https://github-readme-stats.vercel.app/api?username=shimajima-eiji&count_private=true&show_icons=true&hide_border=true&title_color=2a5298&icon_color=1f6feb&theme=default" />
+</a>
+<a href="https://github.com/shimajima-eiji">
+  <img height="165" alt="top languages" src="https://github-readme-stats.vercel.app/api/top-langs/?username=shimajima-eiji&layout=compact&hide_border=true&title_color=2a5298&langs_count=8" />
+</a>
+
+</div>
+
+<!-- ===================== CREDIBILITY ===================== -->
+
+## 🏅 Credibility
+
+第三者評価としての客観指標です。
+
+<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_%E6%8A%80%E8%A1%93%E5%8A%9B-4.30_%28%E4%B8%8A%E4%BD%8D0.46%25%29-1f6feb?style=flat-square&logo=verizon&logoColor=white" alt="LAPRAS tech score" /></a>
+<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_%E5%B8%82%E5%A0%B4%E4%BE%A1%E5%80%A4-4.21_%28%E4%B8%8A%E4%BD%8D0.75%25%29-2a5298?style=flat-square&logo=trustpilot&logoColor=white" alt="LAPRAS market value" /></a>
+
+<!-- ===================== CONTACT ===================== -->
+
+## 📮 Contact
+
+記事の感想・お仕事のご相談など歓迎です。各種エージェントサービスにも登録しています。
+[**Prairie Cards**](https://my.prairie.cards/u/nomuraya) または [**Wantedly**](https://www.wantedly.com/id/nomuraya) からどうぞ。
+**「GitHub プロフィールを見た」** と添えていただけると話が早いです 🙌
+
+<div align="center">
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:b21f1f,50:2a5298,100:1a2a6c&height=120&section=footer" alt="footer" />
+</div>
+
+<!-- ===================== ARCHIVED BADGES (future use) ===================== -->
 <!--
 [![wakatime](https://wakatime.com/badge/user/c2d996c1-f59e-4930-a8aa-735d66822ec3.svg)](https://wakatime.com/@c2d996c1-f59e-4930-a8aa-735d66822ec3)
--->
-<!-- FYI: https://qiita-badge.apiapi.app -->
-<!--
 [![My Qiita contributions](https://qiita-badge.apiapi.app/s/nomurasan/contributions.svg)](http://qiita.com/nomurasan)
-[![My Qiita posts](https://qiita-badge.apiapi.app/s/nomurasan/posts.svg)](http://qiita.com/nomurasan)
-[![My Qiita followers](https://qiita-badge.apiapi.app/s/nomurasan/followers.svg)](http://qiita.com/nomurasan)
+Zenn: 2026-05-19 アカウント凍結のためバッジ無効化
+[![](https://zenn.badge.nikaera.com/s/nomuraya/likes?style=flat)](https://zenn.dev/nomuraya)
 -->
-<!-- Zenn: 2026-05-19 アカウント凍結のためバッジ無効化 -->
-<!-- [![](https://zenn.badge.nikaera.com/s/nomuraya/likes?style=flat)](https://zenn.dev/nomuraya) -->
-<!-- [![](https://zenn.badge.nikaera.com/s/nomuraya/articles?style=flat)](https://zenn.dev/nomuraya/articles) -->
-<!-- [![](https://zenn.badge.nikaera.com/s/nomuraya/followers?style=flat)](https://zenn.dev/nomuraya/followers) -->


### PR DESCRIPTION
## 背景

GitHub プロフィールページ（`shimajima-eiji/shimajima-eiji`）が「宣伝・紹介ページとして見せ方が弱い」という課題。

調べたところ、原因は装飾だけではなく構造的なものでした:

1. **README 全文が `<!-- -->` でコメントアウト** → プロフィールが実質まっさら表示
2. **コンテンツが抽象的・未完成**（「ようこそ！このページは」で途切れ）で、自分の言葉での価値提案がない
3. **GitHub 上に "見せる中身" がなく**、外部リンクへ飛ばすだけのハブ構造
4. **CTA が受け身**（「エージェントサイトに登録しているので活用して」）
5. **アイデンティティ分散**（shimajima-eiji / nomuraya / nomurasan）

## 方針（ユーザー確認済み）

- **主目的：技術発信の読者獲得** → 記事・発信を主役に据え直し
- **中身を厚くする** → GitHub 上に「書いているテーマ」＋「最新記事」を掲載

## 変更点

- 全文コメントアウトを解除し、発信者向けに再設計
- `📝 技術発信 / Writing` セクションを新設（書いているテーマを言語化）
- `🆕 最新記事` を Qiita RSS から自動更新するワークフロー（`.github/workflows/update-articles.yml`）を追加
- LAPRAS スコア / FDE は `🏅 Credibility` として脇役に再配置
- リンク表は発信先（Qiita）を先頭に並べ替え

## レビュー時の確認ポイント

- `update-articles.yml` は cron（毎日）と手動実行で **master へ自動コミット** します。不要なら削除可。手動実行（workflow_dispatch）で最新記事の差し込みを今すぐ試せます。
- Qiita ハンドルは `nomurasan` を採用（既存リンク準拠）。note は確実なハンドルが不明なため未掲載。
- Tech Stack のバッジ構成（言語・ツール）は適宜調整してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnWUfLXoYZZBdU339FKVQ)_