### PR TITLE
chore: デフォルトブランチ改名(master→main)に備えてブランチ名のハードコードを解消

### DIFF
--- a/.github/workflows/issue-image-generator.yml
+++ b/.github/workflows/issue-image-generator.yml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  DEFAULT_BRANCH: master
 
 jobs:
   generate:
@@ -67,7 +66,7 @@ jobs:
         env:
           RELPATH: ${{ steps.generate.outputs.relpath }}
         run: |
-          URL="https://raw.githubusercontent.com/${{ github.repository }}/${{ env.DEFAULT_BRANCH }}/$RELPATH"
+          URL="https://raw.githubusercontent.com/${{ github.repository }}/${{ github.event.repository.default_branch }}/$RELPATH"
 
           BODY=$(cat << EOF_BODY
           🎨 画像を生成しました


### PR DESCRIPTION
## 目的

デフォルトブランチを `master` → `main` に改名する準備。

`issue-image-generator.yml` が `DEFAULT_BRANCH: master` をハードコードしており、改名すると生成画像の raw URL が壊れる。これを `github.event.repository.default_branch` に置き換え、**改名後も無修正で動作**するようにする。

## 変更点

- `env.DEFAULT_BRANCH`（固定値 `master`）を削除
- raw URL の組み立てを `${{ github.event.repository.default_branch }}` に変更

## 補足

リポジトリ内の `master` 参照はこの1か所のみ（grep 確認済み）。`update-articles.yml` / `README.md` には改名で壊れる参照なし。

**デフォルトブランチの切替自体は GitHub の Settings から手動で行う必要があります**（API/CLI が当環境で使えないため）。本PRマージ後にリネームすると安全です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCnWUfLXoYZZBdU339FKVQ)_