### PR TITLE
Bilingual README (English-first) + switch article feed to dev.to

### DIFF
--- a/.github/workflows/update-articles.yml
+++ b/.github/workflows/update-articles.yml
@@ -1,6 +1,6 @@
 name: Update latest articles
 
-# README の「🆕 最新記事」セクションを Qiita の RSS から自動更新する。
+# README の「🆕 最新記事」セクションを dev.to の RSS から自動更新する。
 # <!-- BLOG-POST-LIST:START --> 〜 <!-- BLOG-POST-LIST:END --> の間を差し替える。
 
 on:
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Pull latest Qiita articles into README
+      - name: Pull latest dev.to articles into README
         uses: gautamkrishnar/blog-post-workflow@v1
         with:
-          feed_list: "https://qiita.com/nomurasan/feed"
+          feed_list: "https://dev.to/feed/nomurasan"
           max_post_count: 5
           commit_message: "chore: update latest articles"
           template: "- 📝 [$title]($url)$newline"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 
 <img src="https://capsule-render.vercel.app/api?type=waving&color=0:1a2a6c,50:2a5298,100:b21f1f&height=200&section=header&text=shimajima-eiji&fontSize=46&fontColor=ffffff&fontAlignY=38&desc=Forward%20Deployed%20Engineer%20%2F%20Tech%20Writer&descSize=20&descAlignY=60" alt="header" />
 
-<a href="https://qiita.com/nomurasan">
+<a href="https://dev.to/nomurasan">
   <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=22&pause=1000&color=2A5298&center=true&vCenter=true&width=620&lines=Forward+Deployed+Engineer;I+write+about+AI+x+real-world+ops;Making+the+%22why%22+of+code+explainable" alt="typing" />
 </a>
 
 <br/>
 
-<a href="https://qiita.com/nomurasan"><img src="https://img.shields.io/badge/Qiita_%E3%82%92%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC-55C500?style=for-the-badge&logo=qiita&logoColor=white" alt="Follow on Qiita" /></a>
-<a href="https://shimajima-eiji.github.io/"><img src="https://img.shields.io/badge/%E3%83%9D%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AA%E3%82%AA-2a5298?style=for-the-badge&logo=githubpages&logoColor=white" alt="Portfolio" /></a>
+<a href="https://dev.to/nomurasan"><img src="https://img.shields.io/badge/Follow_on_DEV-0A0A0A?style=for-the-badge&logo=devdotto&logoColor=white" alt="Follow on DEV" /></a>
+<a href="https://qiita.com/nomurasan"><img src="https://img.shields.io/badge/Qiita_(JP)-55C500?style=for-the-badge&logo=qiita&logoColor=white" alt="Qiita" /></a>
+<a href="https://shimajima-eiji.github.io/"><img src="https://img.shields.io/badge/Portfolio-2a5298?style=for-the-badge&logo=githubpages&logoColor=white" alt="Portfolio" /></a>
 
 <br/>
 
@@ -18,26 +19,24 @@
 
 </div>
 
-<!-- ===================== ABOUT ===================== -->
+<!-- ===================================================================== -->
+<!-- ENGLISH SECTION (primary)                                             -->
+<!-- ===================================================================== -->
 
 ## 👋 About
 
-**Forward Deployed Engineer** として顧客の現場に入り、AI を実務に組み込んで課題を解いています。
-その過程で得た **「現場で本当に効いた知見」を技術記事として継続発信** しているのが、私の主な活動です。
-丸暗記ではなく **“なぜそうなるのか” を言語化する** ことを大切にしています。
+I am a **Forward Deployed Engineer**. I work inside the customer's environment and build AI into their actual operations to solve real problems. Alongside that, I write technical articles about what actually worked in the field. I care about explaining **why** something behaves the way it does, not just memorizing how to use it.
 
-<!-- ===================== WRITING (MAIN) ===================== -->
+## 📝 Writing
 
-## 📝 技術発信 / Writing
+Main topics I write about:
 
-書いている主なテーマ:
+- 🤖 **AI × real-world ops** — operational know-how for making Claude Code stick in a working business workflow.
+- ✅ **Quality control for AI-generated output** — automating article fact-checks as a pre-commit gate.
+- 🌱 **Putting the beginner's "why" into words** — explanations that start from the spec, such as how a `for` loop actually works (PHP / JavaScript).
+- 🚀 **How to start publishing** — guides for people who are about to write their first article.
 
-- 🤖 **AI × 実務** — Claude Code を業務ワークフローに定着させる運用知見
-- ✅ **AI 生成物の品質管理** — 記事のファクトチェックを pre-commit ゲートで自動化する取り組み
-- 🌱 **初学者の「なぜ」を言語化** — `for` 文など、仕様から理解する解説（PHP / JavaScript）
-- 🚀 **発信のはじめ方** — Qiita 入門など、これから書く人へのガイド
-
-### 🆕 最新記事
+### 🆕 Latest articles
 
 <!-- BLOG-POST-LIST:START -->- 📝 [Claude Codeに記事管理を任せたら下書きを全体公開された話と、その後に作った3ゲート防衛システム](https://qiita.com/nomurasan/items/faab752edadf859ae122)
 - 📝 [GitHubプロフィールREADMEを「記事を書くだけで育つ」状態にするGitHub Actions設定](https://qiita.com/nomurasan/items/9890e97f782b39bfe651)
@@ -45,9 +44,7 @@
 - 📝 [ブラウザのセキュリティ制約とローカルファイルアクセス - file://プロトコルの罠](https://qiita.com/nomurasan/items/59dcba0159d25b9b4c72)
 <!-- BLOG-POST-LIST:END -->
 
-▶ **もっと読む / フォロー:** [Qiita @nomurasan](https://qiita.com/nomurasan)
-
-<!-- ===================== TECH STACK ===================== -->
+▶ **Read more / follow:** [DEV @nomurasan](https://dev.to/nomurasan)
 
 ## 🧰 Tech Stack
 
@@ -60,17 +57,60 @@
 ![Claude](https://img.shields.io/badge/Claude_Code-D97757?style=flat-square&logo=anthropic&logoColor=white)
 ![OpenAI](https://img.shields.io/badge/OpenAI_API-412991?style=flat-square&logo=openai&logoColor=white)
 
-<!-- ===================== LINKS ===================== -->
-
 ## 🔗 Links
+
+| Page | Summary |
+| ----- | ---- |
+| 🌐 [DEV](https://dev.to/nomurasan) | Technical articles in English (primary) |
+| 📚 [Qiita](https://qiita.com/nomurasan) | Technical articles in Japanese |
+| 🖼️ [Portfolio](https://shimajima-eiji.github.io/) | Slide-style self-introduction and activity log |
+| 🪪 [Prairie Cards](https://my.prairie.cards/u/nomuraya) | Forward Deployed Engineer — business card |
+| 🤝 [Wantedly](https://www.wantedly.com/id/nomuraya) | Profile (viewable without an account) |
+| 📦 [Repositories](https://github.com/shimajima-eiji?tab=repositories) | Public projects and experimental code |
+
+## 📮 Contact
+
+Feedback on my articles and work inquiries are both welcome. Reach me through [**Prairie Cards**](https://my.prairie.cards/u/nomuraya) or [**Wantedly**](https://www.wantedly.com/id/nomuraya). Mentioning **"saw your GitHub profile"** makes it faster to get to the point 🙌
+
+<!-- ===================================================================== -->
+<!-- 日本語セクション (secondary)                                           -->
+<!-- ===================================================================== -->
+
+---
+
+## 👋 自己紹介
+
+**Forward Deployed Engineer** として顧客の現場に入り、AI を実務に組み込んで課題を解いています。あわせて、現場で本当に効いた知見を技術記事として発信しています。丸暗記ではなく、**なぜそうなるのか** を言語化することを大切にしています。
+
+## 📝 技術発信
+
+書いている主なテーマ:
+
+- 🤖 **AI × 実務** — Claude Code を業務ワークフローに定着させる運用知見
+- ✅ **AI 生成物の品質管理** — 記事のファクトチェックを pre-commit ゲートで自動化する取り組み
+- 🌱 **初学者の「なぜ」を言語化** — `for` 文など、仕様から理解する解説（PHP / JavaScript）
+- 🚀 **発信のはじめ方** — Qiita 入門など、これから書く人へのガイド
+
+> 最新記事は上部の英語セクション（DEV）に自動表示しています。日本語の記事は [Qiita @nomurasan](https://qiita.com/nomurasan) にまとめています。
+
+## 🧰 技術スタック
+
+使用技術は上部の英語セクション（Tech Stack）と同じです。
+
+## 🔗 リンク
 
 | ページ | 概要 |
 | ----- | ---- |
-| 📚 [Qiita](https://qiita.com/nomurasan) | 技術記事（メインの発信先） |
+| 🌐 [DEV](https://dev.to/nomurasan) | 英語の技術記事（メインの発信先） |
+| 📚 [Qiita](https://qiita.com/nomurasan) | 日本語の技術記事 |
 | 🖼️ [ポートフォリオサイト](https://shimajima-eiji.github.io/) | スライド形式の自己紹介・活動記録 |
 | 🪪 [Prairie Cards](https://my.prairie.cards/u/nomuraya) | Forward Deployed Engineer — 名刺代わり |
 | 🤝 [Wantedly](https://www.wantedly.com/id/nomuraya) | プロフィール（アカウント不要で閲覧可） |
 | 📦 [Repositories](https://github.com/shimajima-eiji?tab=repositories) | 公開プロジェクト・実験的コード |
+
+## 📮 連絡先
+
+記事の感想・お仕事のご相談など歓迎です。[**Prairie Cards**](https://my.prairie.cards/u/nomuraya) または [**Wantedly**](https://www.wantedly.com/id/nomuraya) からどうぞ。**「GitHub プロフィールを見た」** と添えていただけると話が早いです 🙌
 
 <!-- ===================== STATS ===================== -->
 
@@ -91,18 +131,10 @@
 
 ## 🏅 Credibility
 
-第三者評価としての客観指標です。
+Third-party objective metrics.
 
-<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_%E6%8A%80%E8%A1%93%E5%8A%9B-4.30_%28%E4%B8%8A%E4%BD%8D0.46%25%29-1f6feb?style=flat-square&logo=verizon&logoColor=white" alt="LAPRAS tech score" /></a>
-<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_%E5%B8%82%E5%A0%B4%E4%BE%A1%E5%80%A4-4.21_%28%E4%B8%8A%E4%BD%8D0.75%25%29-2a5298?style=flat-square&logo=trustpilot&logoColor=white" alt="LAPRAS market value" /></a>
-
-<!-- ===================== CONTACT ===================== -->
-
-## 📮 Contact
-
-記事の感想・お仕事のご相談など歓迎です。各種エージェントサービスにも登録しています。
-[**Prairie Cards**](https://my.prairie.cards/u/nomuraya) または [**Wantedly**](https://www.wantedly.com/id/nomuraya) からどうぞ。
-**「GitHub プロフィールを見た」** と添えていただけると話が早いです 🙌
+<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_Tech_Score-4.30_(top_0.46%25)-1f6feb?style=flat-square&logo=verizon&logoColor=white" alt="LAPRAS tech score" /></a>
+<a href="https://lapras.com/person"><img src="https://img.shields.io/badge/LAPRAS_Market_Value-4.21_(top_0.75%25)-2a5298?style=flat-square&logo=trustpilot&logoColor=white" alt="LAPRAS market value" /></a>
 
 <div align="center">
 <img src="https://capsule-render.vercel.app/api?type=waving&color=0:b21f1f,50:2a5298,100:1a2a6c&height=120&section=footer" alt="footer" />

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Main topics I write about:
 
 ### 🆕 Latest articles
 
-<!-- BLOG-POST-LIST:START -->- 📝 [Claude Codeに記事管理を任せたら下書きを全体公開された話と、その後に作った3ゲート防衛システム](https://qiita.com/nomurasan/items/faab752edadf859ae122)
-- 📝 [GitHubプロフィールREADMEを「記事を書くだけで育つ」状態にするGitHub Actions設定](https://qiita.com/nomurasan/items/9890e97f782b39bfe651)
-- 📝 [ITパスポートのアルゴリズム章で計算量&lpar;O記法&rpar;が頭に入らない人へ — Q&amp;Aで詰まりを潰す](https://qiita.com/nomurasan/items/4884d709dbc9517a1472)
-- 📝 [ブラウザのセキュリティ制約とローカルファイルアクセス - file://プロトコルの罠](https://qiita.com/nomurasan/items/59dcba0159d25b9b4c72)
+<!-- BLOG-POST-LIST:START -->- 📝 [AI made generation cheap. It did not make judgment cheap.](https://dev.to/nomurasan/ai-made-generation-cheap-it-did-not-make-judgment-cheap-j97)
+- 📝 [No errors, but the email never arrives — it&#39;s probably not your code](https://dev.to/nomurasan/no-errors-but-the-email-never-arrives-its-probably-not-your-code-5cbe)
+- 📝 [I Copied a Google AI Studio Session by Hand. 68% of the Data Was Gone.](https://dev.to/nomurasan/i-copied-a-google-ai-studio-session-by-hand-68-of-the-data-was-gone-3fhi)
+- 📝 [Why AI Keeps Making the Same Mistake — And Why Correcting It Each Time Doesn&#39;t Work](https://dev.to/nomurasan/why-ai-keeps-making-the-same-mistake-and-why-correcting-it-each-time-doesnt-work-2cpi)
+- 📝 [Stop Telling Your AI to &quot;Be Careful Next Time.&quot; It Has No Memory of Yesterday.](https://dev.to/nomurasan/stop-telling-your-ai-to-be-careful-next-time-it-has-no-memory-of-yesterday-i6c)
 <!-- BLOG-POST-LIST:END -->
 
 ▶ **Read more / follow:** [DEV @nomurasan](https://dev.to/nomurasan)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@
 </div>
 
 <!-- ===================================================================== -->
-<!-- ENGLISH SECTION (primary)                                             -->
+<!-- ENGLISH SECTION (primary) — open by default (pseudo-tab)              -->
 <!-- ===================================================================== -->
+
+<details open>
+<summary><b>🇬🇧 English</b></summary>
 
 ## 👋 About
 
@@ -72,11 +75,14 @@ Main topics I write about:
 
 Feedback on my articles and work inquiries are both welcome. Reach me through [**Prairie Cards**](https://my.prairie.cards/u/nomuraya) or [**Wantedly**](https://www.wantedly.com/id/nomuraya). Mentioning **"saw your GitHub profile"** makes it faster to get to the point 🙌
 
+</details>
+
 <!-- ===================================================================== -->
-<!-- 日本語セクション (secondary)                                           -->
+<!-- 日本語セクション (secondary) — collapsed by default (pseudo-tab)       -->
 <!-- ===================================================================== -->
 
----
+<details>
+<summary><b>🇯🇵 日本語</b></summary>
 
 ## 👋 自己紹介
 
@@ -112,7 +118,9 @@ Feedback on my articles and work inquiries are both welcome. Reach me through [*
 
 記事の感想・お仕事のご相談など歓迎です。[**Prairie Cards**](https://my.prairie.cards/u/nomuraya) または [**Wantedly**](https://www.wantedly.com/id/nomuraya) からどうぞ。**「GitHub プロフィールを見た」** と添えていただけると話が早いです 🙌
 
-<!-- ===================== STATS ===================== -->
+</details>
+
+<!-- ===================== STATS (common / 言語共通) ===================== -->
 
 ## 📈 GitHub Activity
 


### PR DESCRIPTION
## Why
English is now the primary axis for branding and international discoverability. The profile README should read English-first, while still serving Japanese readers on the same page.

## What
- **Bilingual README on one page**: an English section (primary, top) followed by a Japanese section (secondary, bottom). No language-switch link — both live in the same `README.md`. Each section carries About / Writing / Tech Stack (English first).
- **Article feed switched Qiita → dev.to**: the `🆕 Latest articles` feed now pulls from `https://dev.to/feed/nomurasan` (English). The `<!-- BLOG-POST-LIST:START -->` / `:END -->` markers are kept intact so the `Update latest articles` Action keeps writing into the English section.
- **Badges tidied for bilingual layout**: added a DEV badge; kept Qiita as the Japanese feed; LAPRAS credibility badges relabeled in English.
- HERO (capsule-render banner + typing SVG) stays shared at the top; the typing copy is already English.

## Update — collapsible (pseudo-tab) layout
GitHub READMEs cannot run JS, so true tabs are impossible. Switched the two language sections to an HTML5 `<details>` "pseudo-tab" layout:
- **HERO stays always-visible** (banner + typing SVG + badges) above the folds.
- **English is `<details open>`** — expanded by default (English-first / international discoverability; the English content is what a visitor sees first).
- **Japanese is `<details>`** (collapsed) — opens on click.
- `<summary>` uses emoji + language name: `🇬🇧 English` / `🇯🇵 日本語`.
- A blank line follows each `<summary>` so the Markdown inside the `<details>` renders (GitHub's Markdown-in-HTML requirement).
- Shared decorations (GitHub Activity / Credibility / footer) sit **below the folds as common content**, since they apply to both languages.
- The `<!-- BLOG-POST-LIST:START -->` / `:END -->` markers remain inside the English `<details>`. `gautamkrishnar/blog-post-workflow` replaces text between the markers by position, so being inside `<details>` does not affect it — **verified** by a manual `workflow_dispatch` run on this branch (commit `8b38b9a`) which correctly rewrote the marker block with the dev.to feed.

## Notes
- Workflow `schedule` is unchanged (daily), so no additional GitHub Actions usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)